### PR TITLE
bug - multiple provider OAS specs not being shown via UI, latest being linked

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,3 +123,12 @@ test_pact_changed_webhook:
 
 .env:
 	touch .env
+
+publish_contract1: .env 
+	@echo "\n========== STAGE: publish contract + results (success) ==========\n"
+	OPEN_API_FILENAME=products.yml PACT_PROVIDER=FOO1 GIT_COMMIT=FOO1 npm run test:publish -- true
+
+
+publish_contract2: .env 
+	@echo "\n========== STAGE: publish contract + results (success) ==========\n"
+	OPEN_API_FILENAME=products2.yml PACT_PROVIDER=FOO2 GIT_COMMIT=FOO2 npm run test:publish -- true

--- a/oas/products2.yml
+++ b/oas/products2.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.1
 info:
-  title: Product API - 1
+  title: Product API - 2
   description: Pactflow Product API demo
   version: 1.0.0
 paths:

--- a/test/publish.js
+++ b/test/publish.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const axios = require("axios");
 
-const oas = fs.readFileSync(path.join(__dirname, "../oas/products.yml"));
+const oas = fs.readFileSync(path.join(__dirname, `../oas/${process.env.OPEN_API_FILENAME}`));
 const report = fs.readFileSync(path.join(__dirname, "../output/report.md"));
 const success = process.argv[2];
 const version = process.argv[3] || process.env.GIT_COMMIT;
@@ -30,7 +30,7 @@ axios({
   },
   url:
     process.env.PACT_BROKER_BASE_URL +
-    `/contracts/provider/pactflow-example-provider-dredd/version/${version}`,
+    `/contracts/provider/${process.env.PACT_PROVIDER}/version/${version}`,
   data: result,
 })
   .then(() => {


### PR DESCRIPTION
It was raised in Slack [here](https://pact-foundation.slack.com/archives/C9VPNUJR2/p1648221550656049), that there is an issue with the rendering in the UI of provider contracts.

1. Upload an OAS spec for provider 1
  - https://testdemo.pactflow.io/overview/provider/FOO1/consumer/%3F%3F%3F
2. Upload a different OAS spec for provider 2
  - https://testdemo.pactflow.io/overview/provider/FOO2/consumer/%3F%3F%3F
3. After completing step two, when viewing both [FOO1](https://testdemo.pactflow.io/overview/provider/FOO1/consumer/%3F%3F%3F) and [FOO2](https://testdemo.pactflow.io/overview/provider/FOO2/consumer/%3F%3F%3F) provider
  - They both show a provider version of `FOO2`
    - <img width="1512" alt="Screenshot 2022-03-28 at 14 37 27" src="https://user-images.githubusercontent.com/19932401/160410565-530f931c-4c7e-4974-b4fb-880a6ad4070a.png">
    - <img width="1508" alt="Screenshot 2022-03-28 at 14 37 19" src="https://user-images.githubusercontent.com/19932401/160410604-585cd7eb-1764-4079-9d13-062d9e5c3986.png">
  - Both view contract links return the `FOO2` version of the [OAS](https://testdemo.pactflow.io/contracts/bi-directional/provider/FOO2/version/FOO2/provider-contract)
    - <img width="1511" alt="Screenshot 2022-03-28 at 14 37 39" src="https://user-images.githubusercontent.com/19932401/160410185-71e6e4d0-c92c-4ca4-92cd-95533a11497a.png">
    - <img width="1482" alt="Screenshot 2022-03-28 at 14 37 34" src="https://user-images.githubusercontent.com/19932401/160410241-8c50056f-e803-4fa5-a044-de8e2ef35883.png">
  - The `FOO1` version can be viewed, if the user changes the [URL](https://testdemo.pactflow.io/contracts/bi-directional/provider/FOO1/version/FOO1/provider-contract) to `FOO1` - This shows the correct `oas` spec
     - <img width="1509" alt="Screenshot 2022-03-28 at 14 38 05" src="https://user-images.githubusercontent.com/19932401/160410073-05b810ae-cc1d-437d-bd34-f394493f9adc.png">

 
This suggests the specs aren't being overwritten, but we have an issue in the UI in rendering the correct version/contract in the right hand detail view.
